### PR TITLE
Minor naming updates and small changes to the scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
-
+aer_v_3.2
+Output/

--- a/iy_AERm.py
+++ b/iy_AERm.py
@@ -11,7 +11,7 @@ import pyarts as py
 import pyarts.workspace
 import datetime
 
-def main(nelem):
+def main(nelem, model="AER"):
     verbosity = 2
     ws = py.workspace.Workspace(verbosity)
     ws.execute_controlfile("general/general.arts")
@@ -74,13 +74,13 @@ def main(nelem):
     )
 
     ws.ReadLBLRTM(
-        filename="/scratch/uni/u237/data/catalogue/aer/aer_v_3.2/line_file/aer_v_3.2",
+        filename="aer_v_3.2",
         fmin=0.0,
-        fmax=float(1e99),
+        fmax=float(2e12),
         globalquantumnumbers="",
         localquantumnumbers="",
-        normalization_option="None",
-        mirroring_option="None",
+        normalization_option="SFS",
+        mirroring_option="Lorentz",
         population_option="LTE",
         lineshapetype_option="VP",
         cutoff_option="None",
@@ -206,16 +206,12 @@ def main(nelem):
     #Exit
     
     tt_time = datetime.datetime.now().strftime("%Y-%m-%d_%H%M")
-    
-    # out = ( f_grid, p_grid, z_field, t_field, vmr H20, 
-    # abs H20, abs O2, abs[f,z], PlacnkBT )
-    ws.WriteXMLIndexed( "ascii", ws.ybatch_index, ws.out, "Output/" + tt_time + "_out" )
 
 # ====================================================================
 
 # Store results
-    ws.WriteXML( "ascii", ws.f_grid, "Output/" + tt_time + "_fgrid.xml" )
-    ws.WriteXML( "ascii", ws.ybatch_index, "Output/" + tt_time + "_out_ybatch_n.xml" )
+    ws.WriteXML( "ascii", ws.f_grid, "Output/fgrid_" + model + "_" + tt_time + ".xml" )
+    ws.WriteXML( "ascii", ws.iy, "Output/iy_" + model + "_midlat-s_" + tt_time + ".xml" )
 
     print("Success! We reached the finish!")
 

--- a/iy_MPM2020m.py
+++ b/iy_MPM2020m.py
@@ -39,7 +39,6 @@ def main(nelem=1125, model="O2-MPM2020", verbosity = 2):
     def abs_xsec_agenda(ws):
         ws.Ignore(ws.abs_nlte)
         ws.abs_xsec_per_speciesInit()
-        ws.abs_xsec_per_speciesAddPredefinedO2MPM2020()
         ws.abs_xsec_per_speciesAddConts()
     ws.Copy(ws.abs_xsec_agenda, abs_xsec_agenda)
 
@@ -73,6 +72,7 @@ def main(nelem=1125, model="O2-MPM2020", verbosity = 2):
         ws.propmat_clearskyAddXsecAgenda()
         ws.propmat_clearskyAddLines()
         ws.propmat_clearskyForceNegativeToZero()
+        ws.propmat_clearskyAddPredefinedO2MPM2020()
     ws.Copy(ws.propmat_clearsky_agenda, propmat_clearsky_agenda)
     
     # Spectroscopy

--- a/results.py
+++ b/results.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Aug 25 14:36:52 2021
+
+@author: richard
+"""
+
+
+import os
+import pyarts
+import matplotlib.pyplot as plt
+
+types ="O2-TRE05", "O2-MPM2020", "AER"
+
+sim_res = os.listdir('Output')
+
+out = {}
+for typ in types:
+    out[typ] = ''
+
+for fil in sim_res:
+    for typ in types:
+        if f"fgrid_{typ}" in fil:
+            if out[typ] == '':
+                out[typ] = fil
+            else:
+                if os.stat(f"Output/{out[typ]}").st_ctime < os.stat(f"Output/{fil}").st_ctime:
+                    out[typ] = fil
+
+for typ in types:
+    assert out[typ] != '', "Didn't find some of the requires data!"
+
+plt.figure(1)
+plt.clf()
+for typ in types:
+    f = pyarts.xml.load(f"Output/{out[typ]}")
+    y = pyarts.xml.load(f"Output/{out[typ].replace(f'fgrid_{typ}_', f'iy_{typ}_midlat-s_')}")
+    plt.plot(f, y, label=typ)
+plt.legend()
+plt.show()


### PR DESCRIPTION
Alex, I made some small updates having a quick look at this today.  I think there's something wrong with the TRE05 model as well from this.  I am going to have more of a look tomorrow.  I am also running the model without the updates that comes from Oliver, so I'll need to talk to him about those.

I've changed so that you can put your AER catalog in the same folder as these python files without messing with git, or at least just have it in the path that you are reading from (e.g., add it to your path in your bashrc or mac equivalent).  You had it hard-coded to your scratch directory before.  This makes it possible for us both to work with this without having to manually maintain different paths.

I also changed the names of the outputs from AER model to be similar to what the other two are doing.

I also added the output directory to the ignore list.

All in all just small things, but just letting you know I am having a look.  Finally.